### PR TITLE
[packaging] droid-compat-f5321: disable selinux from the kernel cmdline

### DIFF
--- a/rpm/droid-compat-f5321.spec
+++ b/rpm/droid-compat-f5321.spec
@@ -10,7 +10,7 @@
 
 # Various settings
 %define patch_kernel 1
-%define custom_cmdline "lpm_levels.sleep_disabled=1 user_debug=31 androidboot.selinux=permissive msm_rtb.filter=0x3F ehci-hcd.park=3 dwc3.maximum_speed=high dwc3_msm.prop_chg_detect=Y coherent_pool=8M sched_enable_power_aware=1 androidboot.hardware=kugo zram.num_devices=4"
+%define custom_cmdline "selinux=0 lpm_levels.sleep_disabled=1 user_debug=31 androidboot.selinux=permissive msm_rtb.filter=0x3F ehci-hcd.park=3 dwc3.maximum_speed=high dwc3_msm.prop_chg_detect=Y coherent_pool=8M sched_enable_power_aware=1 androidboot.hardware=kugo zram.num_devices=4"
 %define custom_dtb "/usr/lib/devicetrees/msm8956-loire-kugo_generic.dtb"
 
 %define divert_flash_partition_device_info 1


### PR DESCRIPTION
Reference on upstream f512x kernel: https://github.com/mer-hybris/droid-hal-img-boot-f5121/commit/e75706e57e2117675c7313d8f31084091c180e27

Should be safe on older Sailfish OS releases too.

Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>